### PR TITLE
Add default dates to the datepickers. 

### DIFF
--- a/public/interday.js
+++ b/public/interday.js
@@ -15,11 +15,12 @@ document.addEventListener("DOMContentLoaded", function() {
   }
 
   $("#startDate").datetimepicker({
-    format: "L"
+    format: "L",
+    defaultDate: moment().subtract(1, "months").format("L")
   });
   $("#endDate").datetimepicker({
     format: "L",
-    useCurrent: false
+    defaultDate: moment().format("L")
   });
 
   $("#startDate").on("change.datetimepicker", function(e) {

--- a/public/intraday.js
+++ b/public/intraday.js
@@ -15,7 +15,8 @@ document.addEventListener("DOMContentLoaded", function() {
 
   $(function() {
     $("#singledaypicker").datetimepicker({
-      format: "L"
+      format: "L",
+      defaultDate: moment().format("L")
     });
   });
 });


### PR DESCRIPTION
I like your tool! Thank you for creating it! Most of the time I want to see the data for today. That would be a good default, I think. I don't see a reason why there wouldn't be a default. 
For the interday I think a nice default is to view the data for last month. Again, there is no downside to having a default. 
